### PR TITLE
feat: Add chess.com endpoints and elite db infra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ DATABASE_USER= # À remplir avec ce que vous voulez
 DATABASE_PASSWORD= # À remplir avec ce que vous voulez
 DATABASE_URL=postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}
 
+ELITE_DATABASE_HOST=postgres_elite_db
+ELITE_DATABASE_PORT=5432
+ELITE_DATABASE_DB=elitedb
+ELITE_DATABASE_USER=postgres # Modifiez si vous voulez
+ELITE_DATABASE_PASSWORD=postgres # Modifiez si vous voulez
+ELITE_DATABASE_URL=postgresql://${ELITE_DATABASE_USER}:${ELITE_DATABASE_PASSWORD}@${ELITE_DATABASE_HOST}:${ELITE_DATABASE_PORT}/${ELITE_DATABASE_DB}
+
 # ------------------------------------- #
 #  CONFIGURATION DE L'AUTHENTIFICATION  #
 # ------------------------------------- #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       POSTGRES_PASSWORD: ${ELITE_DATABASE_PASSWORD}
     volumes:
       - 'postgres_elite_data:/var/lib/postgresql/data'
+      - './elitedb.sql:/usr/src/app/elitedb.sql'
+
     networks:
       - castled_api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,27 @@ services:
     networks:
       - castled_api
 
+  postgres_elite_db:
+    image: postgres:latest
+    container_name: castled-elite-postgres
+    # On expose le port de la base de données.
+    # Généralement, le port 5432 est utilisé.
+    ports:
+      - '5433:${DATABASE_PORT}'
+    # On définit les variables d'environnement.
+    # Elles sont présentes dans le ficùier .env
+    environment:
+      POSTGRES_DB: ${ELITE_DATABASE_DB}
+      POSTGRES_USER: ${ELITE_DATABASE_USER}
+      POSTGRES_PASSWORD: ${ELITE_DATABASE_PASSWORD}
+    volumes:
+      - 'postgres_elite_data:/var/lib/postgresql/data'
+    networks:
+      - castled_api
+
 volumes:
   postgres_data:
+  postgres_elite_data:
 
 networks:
   castled_api:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^10.4.6",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.4.6",
@@ -1820,6 +1821,17 @@
       "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
       "license": "MIT"
     },
+    "node_modules/@nestjs/axios": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
+      "integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.5.tgz",
@@ -3443,8 +3455,19 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4218,7 +4241,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4525,7 +4547,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5459,6 +5480,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -5532,7 +5574,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8549,6 +8590,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^10.4.6",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.6",

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -18,8 +18,9 @@ import { JwtAuthGuard } from '../authentication/jwt-auth.guard';
 import { User } from '../users/entities/user.entity';
 import { IPaginationOptions, Pagination } from 'nestjs-typeorm-paginate';
 import { Analysis } from './entities/analysis.entity';
-import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '../common/constants';
+import { DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE } from '../common/constants';
 import { AnalysisResponseDto } from './dto/response/analysis-response.dto';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('analysis')
@@ -40,16 +41,16 @@ export class AnalysisController {
 
   @ApiOperation({ summary: "Récupération des analyses de l'utilisateur connecté" })
   @ApiResponse({ status: 200, description: "Liste des analyses de l'utilisateur connecté." })
-  @ApiQuery({ name: 'page', required: true, schema: { default: DEFAULT_PAGE } })
+  @ApiQuery({ name: 'page', required: true, schema: { default: DEFAULT_PAGE_NUMBER } })
   @ApiQuery({ name: 'limit', required: true, schema: { default: DEFAULT_PAGE_SIZE } })
   @Get()
   async findPaginatedByUserId(
-    @Req() request: Request & { user: User },
-    @Query('page') page: number = DEFAULT_PAGE,
+    @CurrentUser() user: User,
+    @Query('page') page: number = DEFAULT_PAGE_NUMBER,
     @Query('limit') limit: number = DEFAULT_PAGE_SIZE,
   ): Promise<Pagination<Analysis>> {
     const options: IPaginationOptions = { page, limit };
-    return this.analysisService.findAllByUserId(request.user.id, options);
+    return this.analysisService.findAllByUserId(user.id, options);
   }
 
   @ApiOperation({ summary: "Récupération d'une analyse avec ses coups par ID" })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { AnalysisModule } from './analysis/analysis.module';
 import { MovesModule } from './moves/moves.module';
 import { InfoResultsModule } from './info-results/info-results.module';
 import { ChessModule } from './chess/chess.module';
+import { ElitedbModule } from './elitedb/elitedb.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ChessModule } from './chess/chess.module';
     InfoResultsModule,
     MovesModule,
     ChessModule,
+    ElitedbModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthenticationModule } from './authentication/authentication.module';
 import { AnalysisModule } from './analysis/analysis.module';
 import { MovesModule } from './moves/moves.module';
 import { InfoResultsModule } from './info-results/info-results.module';
+import { ChessModule } from './chess/chess.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { InfoResultsModule } from './info-results/info-results.module';
     AnalysisModule,
     InfoResultsModule,
     MovesModule,
+    ChessModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/authentication/authentication.controller.ts
+++ b/src/authentication/authentication.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Body, HttpCode, UseGuards } from '@nestjs/common';
 import { AuthenticationService } from './authentication.service';
 import { LoginRequestDto } from './dto/request/login-request.dto';
 import { CreateUserDto } from './dto/request/create-user.dto';
-import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { User } from '../users/entities/user.entity';
 import { LocalAuthGuard } from './local-auth.guard';
 import { AuthenticationResponseDto } from './dto/response/authentication-response.dto';
@@ -57,6 +57,7 @@ export class AuthenticationController {
   @ApiResponse({ status: 200, description: 'Token rafraîchi.' })
   @ApiResponse({ status: 401, description: 'Token invalide.' })
   @ApiResponse({ status: 400, description: 'Requête invalide.' })
+  @ApiBearerAuth('access-token')
   @Post('refresh')
   async refresh(@Body() refreshTokenRequest: RefreshTokenRequestDto): Promise<AuthenticationResponseDto> {
     return this.authService.refresh(refreshTokenRequest.refreshToken);

--- a/src/chess/chess.controller.spec.ts
+++ b/src/chess/chess.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChessController } from './chess.controller';
+
+describe('ChessController', () => {
+  let controller: ChessController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChessController],
+    }).compile();
+
+    controller = module.get<ChessController>(ChessController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/chess/chess.controller.spec.ts
+++ b/src/chess/chess.controller.spec.ts
@@ -1,12 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChessController } from './chess.controller';
+import { ChessService } from './chess.service';
 
 describe('ChessController', () => {
   let controller: ChessController;
+  let module: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       controllers: [ChessController],
+      providers: [
+        {
+          provide: ChessService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<ChessController>(ChessController);

--- a/src/chess/chess.controller.ts
+++ b/src/chess/chess.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('chess')
+export class ChessController {}

--- a/src/chess/chess.controller.ts
+++ b/src/chess/chess.controller.ts
@@ -1,4 +1,31 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
+import { ChessService } from './chess.service';
+import { ApiParam, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @Controller('chess')
-export class ChessController {}
+export class ChessController {
+  constructor(private readonly chessService: ChessService) {}
+
+  @ApiOperation({ summary: 'Récupère le profil d’un joueur par username' })
+  @ApiParam({ name: 'username', description: 'Le pseudonyme du joueur (ex: "erik")' })
+  @ApiResponse({ status: 200, description: 'Profil du joueur récupéré.' })
+  @Get('player/:username')
+  async getChessPlayer(@Param('username') username: string) {
+    return this.chessService.getChessPlayer(username);
+  }
+
+  @ApiOperation({ summary: 'Récupère les parties en cours (“to-move”) pour un joueur' })
+  @ApiParam({ name: 'username', description: 'Le pseudonyme du joueur (ex: "erik")' })
+  @ApiResponse({ status: 200, description: 'Parties en cours récupérées.' })
+  @Get('player/:username/games/to-move')
+  async getPlayerGamesToMove(@Param('username') username: string) {
+    return this.chessService.getPlayerGamesToMove(username);
+  }
+
+  @ApiOperation({ summary: 'Récupère la liste des archives disponibles pour un joueur' })
+  @ApiResponse({ status: 200, description: 'Archives récupérées.' })
+  @Get('player/:username/games')
+  async getPlayerMonthlyGames(@Param('username') username: string) {
+    return this.chessService.getPlayerGames(username);
+  }
+}

--- a/src/chess/chess.module.ts
+++ b/src/chess/chess.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ChessService } from './chess.service';
+import { ChessController } from './chess.controller';
+
+@Module({
+  providers: [ChessService],
+  controllers: [ChessController],
+  exports: [ChessService],
+})
+export class ChessModule {}

--- a/src/chess/chess.module.ts
+++ b/src/chess/chess.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { ChessService } from './chess.service';
 import { ChessController } from './chess.controller';
 
 @Module({
+  imports: [HttpModule],
   providers: [ChessService],
   controllers: [ChessController],
   exports: [ChessService],

--- a/src/chess/chess.service.spec.ts
+++ b/src/chess/chess.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChessService } from './chess.service';
+
+describe('ChessService', () => {
+  let service: ChessService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChessService],
+    }).compile();
+
+    service = module.get<ChessService>(ChessService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/chess/chess.service.spec.ts
+++ b/src/chess/chess.service.spec.ts
@@ -1,11 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChessService } from './chess.service';
+import { HttpModule } from '@nestjs/axios';
 
 describe('ChessService', () => {
   let service: ChessService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       providers: [ChessService],
     }).compile();
 

--- a/src/chess/chess.service.ts
+++ b/src/chess/chess.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ChessService {}

--- a/src/chess/chess.service.ts
+++ b/src/chess/chess.service.ts
@@ -1,4 +1,85 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { lastValueFrom } from 'rxjs';
+import { ChessPlayer } from './interfaces/chess-player.interface';
+import { HttpService } from '@nestjs/axios';
 
 @Injectable()
-export class ChessService {}
+export class ChessService {
+  private readonly logger = new Logger(ChessService.name);
+  private readonly BASE_URL = 'https://api.chess.com/pub';
+
+  constructor(private readonly http: HttpService) {}
+
+  /**
+   * Récupère le profil d’un joueur par username
+   * @param username Le pseudonyme du joueur (ex: 'erik')
+   */
+  async getChessPlayer(username: string): Promise<ChessPlayer> {
+    try {
+      const url = `${this.BASE_URL}/player/${username}`;
+      const response$ = this.http.get<ChessPlayer>(url);
+      const { data } = await lastValueFrom(response$);
+      return data;
+    } catch (error) {
+      this.logger.error(`Erreur lors de la récupération du profil du joueur: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Récupère les parties en cours (“to-move”) pour un joueur
+   */
+  async getPlayerGamesToMove(username: string) {
+    try {
+      const url = `${this.BASE_URL}/player/${username}/games/to-move`;
+      const response$ = this.http.get(url);
+      const { data } = await lastValueFrom(response$);
+      return data;
+    } catch (error) {
+      this.logger.error(`Erreur lors de la récupération des parties en cours pour ${username}: ${error}`);
+      throw error;
+    }
+  }
+
+  async getPlayerGamesMonthly(username: string, year: number, month: number) {
+    try {
+      const url = `${this.BASE_URL}/player/${username}/games/${year}/${month}`;
+      const response$ = this.http.get(url);
+      const { data } = await lastValueFrom(response$);
+      return data;
+    } catch (error) {
+      this.logger.error(`Erreur lors de la récupération des parties mensuelles pour ${username}: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Récupère la liste des archives disponibles pour un joueur (url des endpoints mensuels).
+   */
+  async getPlayerGameArchives(username: string) {
+    try {
+      const url = `${this.BASE_URL}/player/${username}/games/archives`;
+      const response$ = this.http.get(url);
+      const { data } = await lastValueFrom(response$);
+      return data;
+    } catch (error) {
+      this.logger.error(`Erreur lors de la récupération des archives de ${username}: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Récupère les parties d’un joueur
+   */
+  async getPlayerGames(username: string) {
+    try {
+      const url = `${this.BASE_URL}/player/${username}/games`;
+      const response$ = this.http.get(url);
+      const { data } = await lastValueFrom(response$);
+      return data;
+    } catch (error) {
+      this.logger.error(`Erreur lors de la récupération des parties pour ${username} : ${error}`);
+      throw error;
+    }
+  }
+}

--- a/src/chess/interfaces/chess-player.interface.ts
+++ b/src/chess/interfaces/chess-player.interface.ts
@@ -1,0 +1,13 @@
+export interface ChessPlayer {
+  avatar?: string;
+  player_id?: number;
+  url?: string;
+  username: string;
+  title?: string;
+  status?: string;
+  name?: string;
+  country?: string;
+  joined?: number; // timestamp
+  last_online?: number; // timestamp
+  followers?: number;
+}

--- a/src/common/constants/app.constant.ts
+++ b/src/common/constants/app.constant.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_PAGE_SIZE = 10;
-export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_NUMBER = 1;

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -12,12 +12,10 @@ import { User } from '../../users/entities/user.entity';
 export const CurrentUser = createParamDecorator((data: unknown, ctx: ExecutionContext): User => {
   const logger = new Logger('CurrentUser');
   const request = ctx.switchToHttp().getRequest();
-
+  logger.debug("Récupération de l'utilisateur connecté");
   if (!request.user) {
     logger.warn('Aucun utilisateur trouvé dans la requête');
     return null;
   }
-
-  logger.debug(`Utilisateur récupéré: ${request.user.email}`);
   return request.user;
 });

--- a/src/common/dto/user.dto.ts
+++ b/src/common/dto/user.dto.ts
@@ -19,6 +19,6 @@ export class UserDto {
     this.id = user.id;
     this.email = user.email;
     this.username = user.username;
-    this.settings = user.settings ? new UserSettingsDto(user.settings) : null;
+    this.settings = user.settings ? new UserSettingsDto(user.settings) : undefined;
   }
 }

--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -2,10 +2,8 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DATABASE_TYPE } from './database.constants';
 
 export const getDatabaseConfig = (): TypeOrmModuleOptions => ({
-  name: process.env.DATABASE_DB,
   type: DATABASE_TYPE,
   url: process.env.DATABASE_URL,
-  entities: [__dirname + '/../**/*.entity.{js,ts}'],
-  // Si on est en production, on ne veut pas synchroniser pour éviter de perdre des données
+  entities: [__dirname + '/../**/*.entity.{js,ts}', '!' + __dirname + '/../elitedb/**/*.entity.{js,ts}'],
   synchronize: true,
 });

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -2,12 +2,19 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { getDatabaseConfig } from './database.config';
+import { getEliteDatabaseConfig } from './elite-database.config';
 
 @Module({
   imports: [
     TypeOrmModule.forRootAsync({
       useFactory: () => getDatabaseConfig(),
       inject: [ConfigService],
+      name: 'default',
+    }),
+    TypeOrmModule.forRootAsync({
+      useFactory: () => getEliteDatabaseConfig(),
+      inject: [ConfigService],
+      name: 'elitedb',
     }),
   ],
 })

--- a/src/database/elite-database.config.ts
+++ b/src/database/elite-database.config.ts
@@ -2,10 +2,9 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DATABASE_TYPE } from './database.constants';
 
 export const getEliteDatabaseConfig = (): TypeOrmModuleOptions => ({
-  name: process.env.ELITE_DATABASE_DB,
   type: DATABASE_TYPE,
   url: process.env.ELITE_DATABASE_URL,
-  entities: [__dirname + '/../elitedb/*.entity.{js,ts}'],
+  entities: [__dirname + '/../elitedb/entities/*.entity.{js,ts}'],
   // Si on est en production, on ne veut pas synchroniser pour éviter de perdre des données
-  synchronize: true,
+  synchronize: false,
 });

--- a/src/database/elite-database.config.ts
+++ b/src/database/elite-database.config.ts
@@ -1,11 +1,11 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DATABASE_TYPE } from './database.constants';
 
-export const getDatabaseConfig = (): TypeOrmModuleOptions => ({
-  name: process.env.DATABASE_DB,
+export const getEliteDatabaseConfig = (): TypeOrmModuleOptions => ({
+  name: process.env.ELITE_DATABASE_DB,
   type: DATABASE_TYPE,
-  url: process.env.DATABASE_URL,
-  entities: [__dirname + '/../**/*.entity.{js,ts}'],
+  url: process.env.ELITE_DATABASE_URL,
+  entities: [__dirname + '/../elitedb/*.entity.{js,ts}'],
   // Si on est en production, on ne veut pas synchroniser pour éviter de perdre des données
   synchronize: true,
 });

--- a/src/elitedb/elitedb.controller.spec.ts
+++ b/src/elitedb/elitedb.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ElitedbController } from './elitedb.controller';
+
+describe('ElitedbController', () => {
+  let controller: ElitedbController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ElitedbController],
+    }).compile();
+
+    controller = module.get<ElitedbController>(ElitedbController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/elitedb/elitedb.controller.spec.ts
+++ b/src/elitedb/elitedb.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ElitedbController } from './elitedb.controller';
+import { ElitedbService } from './elitedb.service';
 
 describe('ElitedbController', () => {
   let controller: ElitedbController;
@@ -7,6 +8,7 @@ describe('ElitedbController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ElitedbController],
+      providers: [{ provide: ElitedbService, useValue: {} }],
     }).compile();
 
     controller = module.get<ElitedbController>(ElitedbController);

--- a/src/elitedb/elitedb.controller.ts
+++ b/src/elitedb/elitedb.controller.ts
@@ -1,23 +1,29 @@
-import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Query, UsePipes, ValidationPipe } from '@nestjs/common';
 import { ElitedbService } from './elitedb.service';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiQuery } from '@nestjs/swagger';
 
 @Controller('elitedb')
 export class ElitedbController {
   constructor(private readonly elitedbService: ElitedbService) {}
   @Get()
-  @ApiProperty({
-    description: 'Get moves for a given FEN position',
-    required: true,
+  @ApiQuery({
+    name: 'fen',
     type: String,
-    example: '/elitedb?fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR KQkq -',
+    description: 'La position FEN',
+    required: true,
+    example: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+    schema: {
+      default: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+    },
   })
+  @UsePipes(new ValidationPipe({ transform: true }))
   async getMoves(@Query('fen') fen: string) {
     if (!fen) {
       throw new BadRequestException("Missing query param 'fen'");
     }
     const splitFen = fen.split(' ');
     const sanitizedFen = `${splitFen[0]} ${splitFen[2]} ${splitFen[3]}`;
+    console.log(sanitizedFen);
 
     const moves = await this.elitedbService.findMoves(sanitizedFen);
     return moves;

--- a/src/elitedb/elitedb.controller.ts
+++ b/src/elitedb/elitedb.controller.ts
@@ -23,9 +23,7 @@ export class ElitedbController {
     }
     const splitFen = fen.split(' ');
     const sanitizedFen = `${splitFen[0]} ${splitFen[2]} ${splitFen[3]}`;
-    console.log(sanitizedFen);
 
-    const moves = await this.elitedbService.findMoves(sanitizedFen);
-    return moves;
+    return await this.elitedbService.findMoves(sanitizedFen);
   }
 }

--- a/src/elitedb/elitedb.controller.ts
+++ b/src/elitedb/elitedb.controller.ts
@@ -1,0 +1,25 @@
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import { ElitedbService } from './elitedb.service';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Controller('elitedb')
+export class ElitedbController {
+  constructor(private readonly elitedbService: ElitedbService) {}
+  @Get()
+  @ApiProperty({
+    description: 'Get moves for a given FEN position',
+    required: true,
+    type: String,
+    example: '/elitedb?fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR KQkq -',
+  })
+  async getMoves(@Query('fen') fen: string) {
+    if (!fen) {
+      throw new BadRequestException("Missing query param 'fen'");
+    }
+    const splitFen = fen.split(' ');
+    const sanitizedFen = `${splitFen[0]} ${splitFen[2]} ${splitFen[3]}`;
+
+    const moves = await this.elitedbService.findMoves(sanitizedFen);
+    return moves;
+  }
+}

--- a/src/elitedb/elitedb.module.ts
+++ b/src/elitedb/elitedb.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ElitedbService } from './elitedb.service';
+import { ElitedbController } from './elitedb.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ElitedbMove } from './entities/elitedb-move.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ElitedbMove], 'elitedb')],
+  providers: [ElitedbService],
+  controllers: [ElitedbController],
+})
+export class ElitedbModule {}

--- a/src/elitedb/elitedb.service.spec.ts
+++ b/src/elitedb/elitedb.service.spec.ts
@@ -6,7 +6,7 @@ describe('ElitedbService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ElitedbService],
+      providers: [{ provide: 'elitedb_ElitedbMoveRepository', useValue: {} }, ElitedbService],
     }).compile();
 
     service = module.get<ElitedbService>(ElitedbService);

--- a/src/elitedb/elitedb.service.spec.ts
+++ b/src/elitedb/elitedb.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ElitedbService } from './elitedb.service';
+
+describe('ElitedbService', () => {
+  let service: ElitedbService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ElitedbService],
+    }).compile();
+
+    service = module.get<ElitedbService>(ElitedbService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/elitedb/elitedb.service.ts
+++ b/src/elitedb/elitedb.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ElitedbMove } from './entities/elitedb-move.entity';
+import { Repository } from 'typeorm/repository/Repository';
+
+@Injectable()
+export class ElitedbService {
+  constructor(
+    @InjectRepository(ElitedbMove, 'elitedb')
+    private readonly elitedbMoveRepository: Repository<ElitedbMove>,
+  ) {}
+
+  async findMoves(sanitizedFen: string) {
+    return this.elitedbMoveRepository.find({
+      where: { position: sanitizedFen },
+    });
+  }
+}

--- a/src/elitedb/entities/elitedb-move.entity.ts
+++ b/src/elitedb/entities/elitedb-move.entity.ts
@@ -1,12 +1,11 @@
-import { CustomBaseEntity } from 'src/common/entities/custom-base.entity';
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 
-@Entity('elitedb-moves')
-export class ElitedbMove extends CustomBaseEntity {
+@Entity('Move')
+export class ElitedbMove {
   @Column()
   san: string;
 
-  @Column()
+  @PrimaryColumn()
   position: string;
 
   @Column({ default: 0 })

--- a/src/elitedb/entities/elitedb-move.entity.ts
+++ b/src/elitedb/entities/elitedb-move.entity.ts
@@ -1,8 +1,9 @@
-import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { Entity, Column, Index, PrimaryColumn } from 'typeorm';
 
 @Entity('Move')
+@Index(['position', 'san'], { unique: true })
 export class ElitedbMove {
-  @Column()
+  @PrimaryColumn()
   san: string;
 
   @PrimaryColumn()

--- a/src/elitedb/entities/elitedb-move.entity.ts
+++ b/src/elitedb/entities/elitedb-move.entity.ts
@@ -1,0 +1,20 @@
+import { CustomBaseEntity } from 'src/common/entities/custom-base.entity';
+import { Entity, Column } from 'typeorm';
+
+@Entity('elitedb-moves')
+export class ElitedbMove extends CustomBaseEntity {
+  @Column()
+  san: string;
+
+  @Column()
+  position: string;
+
+  @Column({ default: 0 })
+  white: number;
+
+  @Column({ default: 0 })
+  black: number;
+
+  @Column({ default: 0 })
+  draw: number;
+}

--- a/src/info-results/info-results.service.test.ts
+++ b/src/info-results/info-results.service.test.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InfoResultsService } from './info-results.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InfoResult } from 'src/analysis/entities/info-result.entity';
+import { Repository, EntityManager } from 'typeorm';
+import { InfoResultResponseDto } from 'src/analysis/dto/response/info-result-response.dto';
+import { AnalysisMove } from 'src/analysis/entities/analysis-move.entity';
+
+describe('InfoResultsService', () => {
+  let service: InfoResultsService;
+  let infoResultRepository: Repository<InfoResult>;
+  let entityManager: EntityManager;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InfoResultsService,
+        {
+          provide: getRepositoryToken(InfoResult),
+          useValue: {
+            create: jest.fn().mockImplementation((dto) => dto),
+          },
+        },
+        {
+          provide: EntityManager,
+          useValue: {
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<InfoResultsService>(InfoResultsService);
+    infoResultRepository = module.get<Repository<InfoResult>>(getRepositoryToken(InfoResult));
+    entityManager = module.get<EntityManager>(EntityManager);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createInfoResults', () => {
+    it('should create and save info results', async () => {
+      const infoResultDto: InfoResultResponseDto[] = [
+        {
+          type: 'info',
+          depth: 11,
+          selDepth: 1,
+          eval: 1,
+          centiPawns: 37,
+          winChance: 0.5,
+          mate: 0.5,
+          move: 'e4',
+          from: 'e4',
+          to: 'e5',
+          pv: ['pv1'],
+          id: '',
+          createdAt: undefined,
+          updatedAt: undefined,
+          deletedAt: undefined,
+        },
+        {
+          type: 'info',
+          depth: 11,
+          selDepth: 1,
+          eval: 1,
+          centiPawns: 37,
+          winChance: 0.5,
+          mate: 0.5,
+          move: 'e4',
+          from: 'e4',
+          to: 'e5',
+          pv: ['pv1'],
+          id: '',
+          createdAt: undefined,
+          updatedAt: undefined,
+          deletedAt: undefined,
+        },
+      ];
+      const analysisMove: AnalysisMove = new AnalysisMove();
+
+      await service.createInfoResults(infoResultDto, analysisMove, entityManager);
+
+      expect(infoResultRepository.create).toHaveBeenCalledTimes(infoResultDto.length);
+      infoResultDto.forEach((dto) => {
+        expect(infoResultRepository.create).toHaveBeenCalledWith({ ...dto, analysisMove });
+      });
+      expect(entityManager.save).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/users/dto/request/update-user-password.dto.ts
+++ b/src/users/dto/request/update-user-password.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsStrongPassword } from 'class-validator';
+import { i18nValidationMessage } from 'nestjs-i18n';
+
+export class UpdateUserPasswordDto {
+  @ApiProperty({ description: 'The current password of the user', example: 'Password123.' })
+  @IsStrongPassword({}, { message: i18nValidationMessage('validation.IS_STRONG_PASSWORD') })
+  @IsNotEmpty({ message: i18nValidationMessage('validation.IS_NOT_EMPTY') })
+  currentPassword: string;
+
+  @ApiProperty({ description: 'The password of the user', example: 'Password123.' })
+  @IsStrongPassword({}, { message: i18nValidationMessage('validation.IS_STRONG_PASSWORD') })
+  @IsNotEmpty({ message: i18nValidationMessage('validation.IS_NOT_EMPTY') })
+  password: string;
+
+  @ApiProperty({ description: 'The confirm password of the user', example: 'Password123.' })
+  @IsStrongPassword({}, { message: i18nValidationMessage('validation.IS_STRONG_PASSWORD') })
+  @IsNotEmpty({ message: i18nValidationMessage('validation.IS_NOT_EMPTY') })
+  confirmPassword: string;
+}

--- a/src/users/dto/request/update-user.dto.ts
+++ b/src/users/dto/request/update-user.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsEmail, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { i18nValidationMessage } from 'nestjs-i18n';
+
+export class UpdateUserDto {
+  @ApiProperty({ description: "L'email de l'utilisateur", example: 'user@example.com' })
+  @IsEmail({}, { message: i18nValidationMessage('validation.IS_EMAIL') })
+  @IsOptional()
+  email?: string;
+
+  @ApiProperty({ description: 'The username of the user', example: 'john_doe' })
+  @IsString({ message: i18nValidationMessage('validation.IS_STRING') })
+  @IsOptional()
+  username?: string;
+}

--- a/src/users/dto/request/user-request.dto.ts
+++ b/src/users/dto/request/user-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class GetUserByEmailDto {
@@ -15,7 +15,9 @@ export class GetUserByIdDto {
   @ApiProperty({
     example: '123e4567-e89b-12d3-a456-426614174000',
     description: "UUID de l'utilisateur",
+    required: true,
   })
+  @IsUUID()
   @IsNotEmpty()
   id: string;
 }

--- a/src/users/dto/user-settings.dto.ts
+++ b/src/users/dto/user-settings.dto.ts
@@ -1,7 +1,6 @@
 import { IsString, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { i18nValidationMessage } from 'nestjs-i18n';
-import { UserSettings } from '../entities/user-settings.entity';
 
 export class UserSettingsDto {
   @ApiProperty({ description: "La langue de l'utilisateur", example: 'fr' })
@@ -18,9 +17,7 @@ export class UserSettingsDto {
   @IsOptional()
   darkMode?: boolean;
 
-  constructor(settings: UserSettings) {
-    this.language = settings.language;
-    this.theme = settings.theme;
-    this.darkMode = settings.darkMode;
+  constructor(settings: Partial<UserSettingsDto>) {
+    Object.assign(this, settings);
   }
 }

--- a/src/users/user-settings.controller.ts
+++ b/src/users/user-settings.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Put, Body, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { Controller, Get, Put, Body, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../authentication/jwt-auth.guard';
 import { UserSettingsService } from './user-settings.service';
 import { UserSettingsDto } from './dto/user-settings.dto';
@@ -11,6 +11,7 @@ import { User } from './entities/user.entity';
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth('access-token')
 export class UserSettingsController {
+  private readonly logger = new Logger(UserSettingsController.name);
   constructor(private readonly settingsService: UserSettingsService) {}
 
   /**
@@ -18,7 +19,7 @@ export class UserSettingsController {
    */
   @Get()
   @ApiOperation({ summary: "Récupération des paramètres de l'utilisateur" })
-  getSettings(@CurrentUser() user: User) {
+  getSettings(@CurrentUser() user: User): Promise<UserSettingsDto> {
     return this.settingsService.getSettings(user);
   }
 
@@ -27,7 +28,12 @@ export class UserSettingsController {
    */
   @Put()
   @ApiOperation({ summary: "Mise à jour des paramètres de l'utilisateur" })
-  updateSettings(@CurrentUser() user: User, @Body() updateSettingsDto: UserSettingsDto) {
+  @ApiBody({ type: UserSettingsDto })
+  @ApiBearerAuth('access-token')
+  updateSettings(@CurrentUser() user: User, @Body() updateSettingsDto: UserSettingsDto): Promise<UserSettingsDto> {
+    this.logger.debug(
+      `Mise à jour des paramètres de l'utilisateur avec l'ID ${user.id}: ${JSON.stringify(updateSettingsDto)}`,
+    );
     return this.settingsService.updateSettings(user, updateSettingsDto);
   }
 }

--- a/src/users/user-settings.service.ts
+++ b/src/users/user-settings.service.ts
@@ -1,5 +1,5 @@
 // src/users/settings.service.ts
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserSettings } from './entities/user-settings.entity';
@@ -8,6 +8,7 @@ import { User } from './entities/user.entity';
 
 @Injectable()
 export class UserSettingsService {
+  private readonly logger = new Logger(UserSettingsService.name);
   constructor(
     @InjectRepository(UserSettings)
     private readonly settingsRepository: Repository<UserSettings>,
@@ -18,17 +19,24 @@ export class UserSettingsService {
    * @param user L'utilisateur dont on veut modifier les paramètres
    * @param updateSettingsDto Les nouveaux paramètres
    * @returns Les paramètres mis à jour
+   * @throws NotFoundException si les paramètres n'existent pas
    */
   async updateSettings(user: User, updateSettingsDto: UserSettingsDto): Promise<UserSettings> {
-    const settings = await this.settingsRepository.findOne({
-      where: { user: { id: user.id } },
-    });
+    this.logger.debug(
+      `Nouveaux paramètres de l'utilisateur avec l'ID ${user.id}: ${JSON.stringify(updateSettingsDto)}`,
+    );
+    const settings: UserSettings = await this.getSettings(user);
 
-    if (!settings) {
-      throw new NotFoundException("Les paramètres de l'utilisateur n'existent pas");
+    this.logger.debug(`Mise à jour des paramètres de l'utilisateur avec l'ID ${user.id}`);
+
+    const hasChanges = Object.keys(updateSettingsDto).some((key) => updateSettingsDto[key] !== settings[key]);
+
+    if (!hasChanges) {
+      throw new ConflictException('Aucun changement détecté');
     }
 
     Object.assign(settings, updateSettingsDto);
+
     return this.settingsRepository.save(settings);
   }
 
@@ -36,15 +44,19 @@ export class UserSettingsService {
    * Récupère les paramètres d'un utilisateur
    * @param user L'utilisateur dont on veut récupérer les paramètres
    * @returns Les paramètres de l'utilisateur
+   * @throws NotFoundException si les paramètres n'existent pas
    */
   async getSettings(user: User): Promise<UserSettings> {
-    const settings = await this.settingsRepository.findOne({
+    const settings: UserSettings = await this.settingsRepository.findOne({
       where: { user: { id: user.id } },
     });
 
     if (!settings) {
+      this.logger.error(`Les paramètres de l'utilisateur avec l'ID ${user.id} n'existent pas`);
       throw new NotFoundException("Les paramètres de l'utilisateur n'existent pas");
     }
+
+    this.logger.debug(`Récupération des paramètres de l'utilisateur avec l'ID ${user.id}`);
 
     return settings;
   }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,14 +1,27 @@
-import { Controller, Get, Param, ParseUUIDPipe, ValidationPipe, UseGuards, NotFoundException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Param,
+  ValidationPipe,
+  UseGuards,
+  NotFoundException,
+  Put,
+  Patch,
+  UsePipes,
+  Body,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiParam, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { I18nService } from 'nestjs-i18n';
 import { UserDto } from 'src/common/dto/user.dto';
-import { GetUserByEmailDto, GetUserByIdDto } from './dto/request/user-request.dto';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { JwtAuthGuard } from 'src/authentication/jwt-auth.guard';
 import { User } from './entities/user.entity';
+import { UpdateUserDto } from './dto/request/update-user.dto';
+import { UpdateUserPasswordDto } from './dto/request/update-user-password.dto';
+import { GetUserByEmailDto, GetUserByIdDto } from './dto/request/user-request.dto';
 
-@ApiTags('Utilisateurs')
+@ApiBearerAuth('access-token')
 @Controller('user')
 @UseGuards(JwtAuthGuard)
 export class UsersController {
@@ -18,11 +31,29 @@ export class UsersController {
   ) {}
 
   /**
+   * Récupère les informations de l'utilisateur connecté.
+   * |----------------------------------------------------------------------------------------|
+   * | ATTENTION : Laisser cette route en premier pour éviter les conflits avec le get(':id') |
+   * |----------------------------------------------------------------------------------------|
+   * @param user
+   */
+  @Get('me')
+  @ApiOperation({ summary: "Récupérer les informations de l'utilisateur connecté" })
+  @ApiResponse({ status: 200, description: 'Utilisateur trouvé', type: UserDto })
+  @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
+  @ApiResponse({ status: 401, description: 'Non autorisé' })
+  @ApiResponse({ status: 400, description: 'Requête invalide' })
+  async getMe(@CurrentUser() user: User): Promise<UserDto> {
+    const currentUser = await this.usersService.findOneByIdWithSettings(user.id);
+    return new UserDto(currentUser);
+  }
+
+  /**
    * Récupère un utilisateur par son identifiant.
    *
-   * @param id - L'identifiant UUID de l'utilisateur
    * @throws NotFoundException si l'utilisateur n'est pas trouvé
    * @returns Les informations de l'utilisateur
+   * @param getUserByIdDto - Les informations de l'utilisateur à rechercher
    */
   @Get(':id')
   @ApiOperation({ summary: 'Récupérer un utilisateur par ID' })
@@ -35,17 +66,18 @@ export class UsersController {
   })
   @ApiResponse({ status: 200, description: 'Utilisateur trouvé', type: UserDto })
   @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
-  async getUserById(@Param('id', ParseUUIDPipe) { id }: GetUserByIdDto): Promise<UserDto> {
-    const user = await this.usersService.findOneById(id);
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async getUserById(@Param() getUserByIdDto: GetUserByIdDto): Promise<UserDto> {
+    const user = await this.usersService.findOneById(getUserByIdDto.id);
     return new UserDto(user);
   }
 
   /**
    * Récupère un utilisateur par son email.
    *
-   * @param email - L'adresse email de l'utilisateur
    * @throws NotFoundException si l'utilisateur n'est pas trouvé
    * @returns Les informations de l'utilisateur
+   * @param getUserByEmailDto - Les informations de l'utilisateur à rechercher
    */
   @Get('email/:email')
   @ApiOperation({ summary: 'Récupérer un utilisateur par email' })
@@ -58,23 +90,38 @@ export class UsersController {
   })
   @ApiResponse({ status: 200, description: 'Utilisateur trouvé', type: UserDto })
   @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
-  async getUserByEmail(
-    @Param(new ValidationPipe({ transform: true }))
-    { email }: GetUserByEmailDto,
-  ): Promise<UserDto> {
-    const user = await this.usersService.findOneByEmail(email);
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async getUserByEmail(@Param() getUserByEmailDto: GetUserByEmailDto): Promise<UserDto> {
+    const user: User = await this.usersService.findOneByEmail(getUserByEmailDto.email);
     if (!user) {
       throw new NotFoundException(this.i18n.translate('user.errors.notFound'));
     }
     return new UserDto(user);
   }
 
-  @Get('me')
-  @ApiOperation({ summary: "Récupérer les informations de l'utilisateur connecté" })
-  @ApiResponse({ status: 200, description: 'Utilisateur trouvé', type: UserDto })
-  @ApiBearerAuth('access-token')
-  async getMe(@CurrentUser() user: User): Promise<UserDto> {
-    const currentUser = await this.usersService.findOneByIdWithSettings(user.id);
-    return new UserDto(currentUser);
+  @Put('me')
+  @ApiOperation({ summary: "Modifier les informations de l'utilisateur connecté" })
+  @ApiBody({ type: UpdateUserDto })
+  @ApiResponse({ status: 200, description: 'Utilisateur mis à jour', type: UserDto })
+  @ApiResponse({ status: 400, description: 'Requête invalide' })
+  @ApiResponse({ status: 401, description: 'Non autorisé' })
+  @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
+  @ApiResponse({ status: 409, description: "Information(s) identique à l'ancienne" })
+  async updateUser(@CurrentUser() user: User, @Body() updateUserDto: UpdateUserDto): Promise<UserDto> {
+    const updatedUser = await this.usersService.update(user.id, updateUserDto);
+    return new UserDto(updatedUser);
+  }
+
+  @Patch('me/password')
+  @ApiOperation({ summary: "Modifier le mot de passe de l'utilisateur connecté" })
+  @ApiBody({ type: UpdateUserPasswordDto })
+  @ApiResponse({ status: 200, description: 'Mot de passe mis à jour', type: UserDto })
+  @ApiResponse({ status: 400, description: 'Requête invalide' })
+  @ApiResponse({ status: 401, description: 'Non autorisé' })
+  @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
+  @ApiResponse({ status: 409, description: "Mot de passe identique à l'ancien" })
+  async updatePassword(@CurrentUser() user: User, updateUserPasswordDto: UpdateUserPasswordDto): Promise<UserDto> {
+    const updatedUser = await this.usersService.updatePassword(user.id, updateUserPasswordDto);
+    return new UserDto(updatedUser);
   }
 }


### PR DESCRIPTION
As a chess enthusiast, I want dedicated endpoints for chess.com along with an enhanced database infrastructure so that data retrieval and storage are fast and scalable.
Endpoints must offer quick, reliable access to game data from chess.com.
The upgraded database setup ensures low latency and efficient handling during peak loads.